### PR TITLE
[base-platform] Add PR build check workflow

### DIFF
--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,0 +1,37 @@
+name: PR Build Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Checkout parent-pom
+        uses: actions/checkout@v4
+        with:
+          repository: hvantran/parent-pom
+          path: parent-pom
+          token: ${{ secrets.ACCESS_TOKEN }}
+      
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+      
+      - name: Build parent-pom
+        run: mvn clean install -f parent-pom/pom.xml -DskipTests
+      
+      - name: Build base-platform
+        run: mvn clean verify -B -Ddockerfile.skip=true
+      
+      - name: Run tests
+        run: mvn test -B -Ddockerfile.skip=true


### PR DESCRIPTION
## Overview
Add pull request CI workflow to validate Maven builds and tests with parent-pom dependency before merging.

## Changes
- Added `.github/workflows/pr-ci.yaml`
- Triggers on pull requests to main branch
- Checks out parent-pom dependency
- Runs Maven build verification
- Executes automated tests

## Benefits
- Early detection of build/test failures
- Improved code quality
- Better PR review process
- Prevents broken code from reaching main branch

## Related Issue
hvantran/project-management#190